### PR TITLE
Update test_paramtest_<type>.<algorithm>.R

### DIFF
--- a/inst/paramtest/test_paramtest_<type>.<algorithm>.R
+++ b/inst/paramtest/test_paramtest_<type>.<algorithm>.R
@@ -15,7 +15,7 @@ test_that("<type>.<algorithm>", {
 
   ParamTest = run_paramtest(learner, fun, exclude)
   expect_true(ParamTest, info = paste0("\nMissing parameters:\n",
-    paste0("- '", ParamTest$missing,"'", collapse = "\n")))
+    paste0("- '", ParamTest$missing, "'", collapse = "\n")))
 })
 
 # example for checking a "control" function of a learner
@@ -28,5 +28,5 @@ test_that("<type>.<algorithm>_control", {
 
   ParamTest = run_paramtest(learner, fun, exclude)
   expect_true(ParamTest, info = paste0("\nMissing parameters:\n",
-    paste0("- '", ParamTest$missing,"'", collapse = "\n")))
+    paste0("- '", ParamTest$missing, "'", collapse = "\n")))
 })


### PR DESCRIPTION
add space to paramtest args to prevent lintr error